### PR TITLE
Add `v1` to proto package name.

### DIFF
--- a/v1/proto/gsii/gsii.proto
+++ b/v1/proto/gsii/gsii.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 import "github.com/openconfig/gnmi/proto/gnmi/gnmi.proto";
 
-package gsii;
+package gsii.v1;
 
 option go_package = "github.com/openconfig/gsii/v1/proto/gsii;gsii";
 


### PR DESCRIPTION
```
 * (M) v1/proto/gsii/gsii.proto
  - Add v1 to protobuf package name to differentiate between versions.
```
